### PR TITLE
[feat] Kakao Oauth 인증 생성

### DIFF
--- a/src/main/java/com/umcreligo/umcback/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/SecurityConfig.java
@@ -2,9 +2,11 @@ package com.umcreligo.umcback.global.config.security;
 
 import com.umcreligo.umcback.domain.user.repository.UserRepository;
 import com.umcreligo.umcback.global.config.security.jwt.KakaoOAuthService;
+import com.umcreligo.umcback.global.config.security.jwt.NaverOAuthService;
 import com.umcreligo.umcback.global.config.security.jwt.filter.JwtAuthenticationFilter;
 import com.umcreligo.umcback.global.config.security.jwt.filter.JwtAuthorizationFilter;
-import com.umcreligo.umcback.global.config.security.jwt.filter.OauthAuthenticationFilter;
+import com.umcreligo.umcback.global.config.security.jwt.filter.KakaoAuthenticationFilter;
+import com.umcreligo.umcback.global.config.security.jwt.filter.NaverAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +37,8 @@ public class SecurityConfig {
     private final AuthenticationManagerBuilder authManagerBuilder;
     private final KakaoOAuthService kakaoOAuthService;
 
+    private final NaverOAuthService naverOAuthService;
+
     private final UserRepository userRepository;
 
     private final PasswordEncoder passwordEncoder;
@@ -60,11 +64,18 @@ public class SecurityConfig {
         authenticationFilter.setAuthenticationSuccessHandler(successHandler);
         authenticationFilter.setAuthenticationFailureHandler(failureHandler);
 
-        OauthAuthenticationFilter customKakaoAuthenticationFilter
-            = new OauthAuthenticationFilter(kakaoOAuthService, userRepository, authManagerBuilder.getOrBuild(),passwordEncoder,entityManagerFactory);
+        KakaoAuthenticationFilter customKakaoAuthenticationFilter
+            = new KakaoAuthenticationFilter(kakaoOAuthService, userRepository, authManagerBuilder.getOrBuild(),passwordEncoder,entityManagerFactory);
         customKakaoAuthenticationFilter.setFilterProcessesUrl("/user/kakao");
         customKakaoAuthenticationFilter.setAuthenticationSuccessHandler(successHandler);
         customKakaoAuthenticationFilter.setAuthenticationFailureHandler(failureHandler);
+
+        NaverAuthenticationFilter customNaverAuthenticationFilter
+            = new NaverAuthenticationFilter(naverOAuthService, userRepository, authManagerBuilder.getOrBuild(),passwordEncoder,entityManagerFactory);
+        customNaverAuthenticationFilter.setFilterProcessesUrl("/user/naver");
+        customNaverAuthenticationFilter.setAuthenticationSuccessHandler(successHandler);
+        customNaverAuthenticationFilter.setAuthenticationFailureHandler(failureHandler);
+
 
 
         http.csrf().disable()

--- a/src/main/java/com/umcreligo/umcback/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/SecurityConfig.java
@@ -1,8 +1,10 @@
 package com.umcreligo.umcback.global.config.security;
 
 import com.umcreligo.umcback.domain.user.repository.UserRepository;
+import com.umcreligo.umcback.global.config.security.jwt.KakaoOAuthService;
 import com.umcreligo.umcback.global.config.security.jwt.filter.JwtAuthenticationFilter;
 import com.umcreligo.umcback.global.config.security.jwt.filter.JwtAuthorizationFilter;
+import com.umcreligo.umcback.global.config.security.jwt.filter.OauthAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,6 +33,7 @@ public class SecurityConfig {
     private final AuthenticationSuccessHandler successHandler;
     private final AuthenticationFailureHandler failureHandler;
     private final AuthenticationManagerBuilder authManagerBuilder;
+    private final KakaoOAuthService kakaoOAuthService;
 
     private final UserRepository userRepository;
 
@@ -56,6 +59,13 @@ public class SecurityConfig {
         authenticationFilter.setFilterProcessesUrl("/user/login");
         authenticationFilter.setAuthenticationSuccessHandler(successHandler);
         authenticationFilter.setAuthenticationFailureHandler(failureHandler);
+
+        OauthAuthenticationFilter customKakaoAuthenticationFilter
+            = new OauthAuthenticationFilter(kakaoOAuthService, userRepository, authManagerBuilder.getOrBuild(),passwordEncoder,entityManagerFactory);
+        customKakaoAuthenticationFilter.setFilterProcessesUrl("/user/kakao");
+        customKakaoAuthenticationFilter.setAuthenticationSuccessHandler(successHandler);
+        customKakaoAuthenticationFilter.setAuthenticationFailureHandler(failureHandler);
+
 
         http.csrf().disable()
                 .sessionManagement()

--- a/src/main/java/com/umcreligo/umcback/global/config/security/jwt/KakaoOAuthService.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/jwt/KakaoOAuthService.java
@@ -1,0 +1,45 @@
+package com.umcreligo.umcback.global.config.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Service
+public class KakaoOAuthService {
+
+    public static final String Kakao_PROFILE_URL = "https://kapi.kakao.com/v2/user/me";
+    public KakaoProfile getKakaoProfileWithAccessToken(String accessToken) {
+        try {
+
+            HttpHeaders header = new HttpHeaders();
+            header.add(AUTHORIZATION, "Bearer " + accessToken);
+            header.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            RestTemplate rt = new RestTemplate();
+            rt.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+            HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(header);
+
+            ResponseEntity<String> response = rt.exchange(
+                Kakao_PROFILE_URL,
+                HttpMethod.POST,
+                request,
+                String.class
+            );
+
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(response.getBody(), KakaoProfile.class);
+
+        } catch (Exception e) {
+            throw new AuthenticationCredentialsNotFoundException("SNS 로그인에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/umcreligo/umcback/global/config/security/jwt/KakaoProfile.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/jwt/KakaoProfile.java
@@ -1,0 +1,17 @@
+package com.umcreligo.umcback.global.config.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class KakaoProfile {
+    private Long id;
+    private String connected_at;
+    private Map<String, Object> properties;
+    private Map<String, Object> kakao_account;
+}

--- a/src/main/java/com/umcreligo/umcback/global/config/security/jwt/NaverOAuthService.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/jwt/NaverOAuthService.java
@@ -1,0 +1,45 @@
+package com.umcreligo.umcback.global.config.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Service
+public class NaverOAuthService {
+
+    public static final String Naver_PROFILE_URL = "https://openapi.naver.com/v1/nid/me";
+    public NaverProfile getKakaoProfileWithAccessToken(String accessToken) {
+        try {
+
+            HttpHeaders header = new HttpHeaders();
+            header.add(AUTHORIZATION, "Bearer " + accessToken);
+            header.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            RestTemplate rt = new RestTemplate();
+            rt.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+            HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(header);
+
+            ResponseEntity<String> response = rt.exchange(
+                Naver_PROFILE_URL,
+                HttpMethod.POST,
+                request,
+                String.class
+            );
+
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(response.getBody(), NaverProfile.class);
+
+        } catch (Exception e) {
+            throw new AuthenticationCredentialsNotFoundException("SNS 로그인에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/umcreligo/umcback/global/config/security/jwt/NaverProfile.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/jwt/NaverProfile.java
@@ -1,0 +1,16 @@
+package com.umcreligo.umcback.global.config.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class NaverProfile {
+    private String resultCode;
+    private String message;
+    private Map<String, Object> response;
+}

--- a/src/main/java/com/umcreligo/umcback/global/config/security/jwt/exception/JwtExceptionHandler.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/jwt/exception/JwtExceptionHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -69,6 +70,11 @@ public class JwtExceptionHandler {
         return ResponseEntity
             .status(INVALID_VALUE.getHttpStatus())
             .body(new ErrorResponse(customException));
+    }
+
+    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+    public ResponseEntity<BaseResponse> handleAuthenticationCredentialsNotFoundException(HttpMessageNotReadableException e) {
+        return ResponseEntity.badRequest().body(new BaseResponse<>(BaseResponseStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/com/umcreligo/umcback/global/config/security/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/jwt/filter/JwtAuthorizationFilter.java
@@ -40,6 +40,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter { //Jwt올바�
         return (
                 // TODO 인증이 필요없는 로직 추가
             (pathMatcher.match("/user/login", path) && request.getMethod().equals("POST")) ||
+                (pathMatcher.match("/user/kakao", path) && request.getMethod().equals("POST")) ||
+                (pathMatcher.match("/user/naver", path) && request.getMethod().equals("POST")) ||
                     pathMatcher.match("/swagger-ui/**", path) ||
                     pathMatcher.match("/favicon.ico", path) ||
                 pathMatcher.match("/swagger-resources/**", path) ||

--- a/src/main/java/com/umcreligo/umcback/global/config/security/jwt/filter/KakaoAuthenticationFilter.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/jwt/filter/KakaoAuthenticationFilter.java
@@ -1,0 +1,68 @@
+package com.umcreligo.umcback.global.config.security.jwt.filter;
+
+import com.umcreligo.umcback.domain.user.domain.User;
+import com.umcreligo.umcback.domain.user.repository.UserRepository;
+import com.umcreligo.umcback.global.config.security.jwt.KakaoOAuthService;
+import com.umcreligo.umcback.global.config.security.jwt.KakaoProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.Optional;
+
+import static com.umcreligo.umcback.global.config.security.jwt.JwtService.TOKEN_HEADER_PREFIX;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RequiredArgsConstructor
+public class KakaoAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+
+    private final KakaoOAuthService kakaoOAuthService;
+    private final UserRepository userRepository;
+    private final AuthenticationManager authenticationManager;
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final EntityManagerFactory enf;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        EntityManager em = enf.createEntityManager();
+        String authorizationHeader = request.getHeader(AUTHORIZATION);
+        if (authorizationHeader == null || !authorizationHeader.startsWith(TOKEN_HEADER_PREFIX)) {
+            throw new AuthenticationCredentialsNotFoundException("AccessToken이 존재하지 않습니다.");
+        }
+        String accessToken = authorizationHeader.substring(TOKEN_HEADER_PREFIX.length());
+        KakaoProfile kakaoProfile = kakaoOAuthService.getKakaoProfileWithAccessToken(accessToken);
+        String email = (String) kakaoProfile.getKakao_account().get("email");
+        email +="kakao";
+        Optional<User> option = userRepository.findByEmail(email);
+        if(!option.isPresent()){
+            //디비 저장하기 위한 transaction 만들기
+            EntityTransaction transaction = em.getTransaction();
+            transaction.begin();
+            String password = "kakao";
+            String encodedPassword = passwordEncoder.encode(password);
+            User user = new User();
+            user.setEmail(email);
+            user.setPassword(encodedPassword);
+            user.setStatus(User.UserStatus.ACTIVE);
+            userRepository.save(user);
+            transaction.commit();
+
+        }
+        Authentication auth = new UsernamePasswordAuthenticationToken(email,"kakao" );
+        return authenticationManager.authenticate(auth);
+    }
+}

--- a/src/main/java/com/umcreligo/umcback/global/config/security/jwt/filter/NaverAuthenticationFilter.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/jwt/filter/NaverAuthenticationFilter.java
@@ -4,6 +4,8 @@ import com.umcreligo.umcback.domain.user.domain.User;
 import com.umcreligo.umcback.domain.user.repository.UserRepository;
 import com.umcreligo.umcback.global.config.security.jwt.KakaoOAuthService;
 import com.umcreligo.umcback.global.config.security.jwt.KakaoProfile;
+import com.umcreligo.umcback.global.config.security.jwt.NaverOAuthService;
+import com.umcreligo.umcback.global.config.security.jwt.NaverProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -25,10 +27,9 @@ import static com.umcreligo.umcback.global.config.security.jwt.JwtService.TOKEN_
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @RequiredArgsConstructor
-public class OauthAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+public class NaverAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
-
-    private final KakaoOAuthService kakaoOAuthService;
+    private final NaverOAuthService naverOAuthService;
     private final UserRepository userRepository;
     private final AuthenticationManager authenticationManager;
 
@@ -44,15 +45,15 @@ public class OauthAuthenticationFilter extends UsernamePasswordAuthenticationFil
             throw new AuthenticationCredentialsNotFoundException("AccessToken이 존재하지 않습니다.");
         }
         String accessToken = authorizationHeader.substring(TOKEN_HEADER_PREFIX.length());
-        KakaoProfile kakaoProfile = kakaoOAuthService.getKakaoProfileWithAccessToken(accessToken);
-        String email = (String) kakaoProfile.getKakao_account().get("email");
-        email +="kakao";
+        NaverProfile naverProfile = naverOAuthService.getKakaoProfileWithAccessToken(accessToken);
+        String email = (String) naverProfile.getResponse().get("email");
+        email +="naver";
         Optional<User> option = userRepository.findByEmail(email);
         if(!option.isPresent()){
             //디비 저장하기 위한 transaction 만들기
             EntityTransaction transaction = em.getTransaction();
             transaction.begin();
-            String password = "kakao";
+            String password = "naver";
             String encodedPassword = passwordEncoder.encode(password);
             User user = new User();
             user.setEmail(email);
@@ -62,7 +63,7 @@ public class OauthAuthenticationFilter extends UsernamePasswordAuthenticationFil
             transaction.commit();
 
         }
-        Authentication auth = new UsernamePasswordAuthenticationToken(email,"kakao" );
+        Authentication auth = new UsernamePasswordAuthenticationToken(email,"naver" );
         return authenticationManager.authenticate(auth);
     }
 }

--- a/src/main/java/com/umcreligo/umcback/global/config/security/jwt/filter/OauthAuthenticationFilter.java
+++ b/src/main/java/com/umcreligo/umcback/global/config/security/jwt/filter/OauthAuthenticationFilter.java
@@ -1,0 +1,68 @@
+package com.umcreligo.umcback.global.config.security.jwt.filter;
+
+import com.umcreligo.umcback.domain.user.domain.User;
+import com.umcreligo.umcback.domain.user.repository.UserRepository;
+import com.umcreligo.umcback.global.config.security.jwt.KakaoOAuthService;
+import com.umcreligo.umcback.global.config.security.jwt.KakaoProfile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.Optional;
+
+import static com.umcreligo.umcback.global.config.security.jwt.JwtService.TOKEN_HEADER_PREFIX;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RequiredArgsConstructor
+public class OauthAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+
+    private final KakaoOAuthService kakaoOAuthService;
+    private final UserRepository userRepository;
+    private final AuthenticationManager authenticationManager;
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final EntityManagerFactory enf;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        EntityManager em = enf.createEntityManager();
+        String authorizationHeader = request.getHeader(AUTHORIZATION);
+        if (authorizationHeader == null || !authorizationHeader.startsWith(TOKEN_HEADER_PREFIX)) {
+            throw new AuthenticationCredentialsNotFoundException("AccessToken이 존재하지 않습니다.");
+        }
+        String accessToken = authorizationHeader.substring(TOKEN_HEADER_PREFIX.length());
+        KakaoProfile kakaoProfile = kakaoOAuthService.getKakaoProfileWithAccessToken(accessToken);
+        String email = (String) kakaoProfile.getKakao_account().get("email");
+        email +="kakao";
+        Optional<User> option = userRepository.findByEmail(email);
+        if(!option.isPresent()){
+            //디비 저장하기 위한 transaction 만들기
+            EntityTransaction transaction = em.getTransaction();
+            transaction.begin();
+            String password = "kakao";
+            String encodedPassword = passwordEncoder.encode(password);
+            User user = new User();
+            user.setEmail(email);
+            user.setPassword(encodedPassword);
+            user.setStatus(User.UserStatus.ACTIVE);
+            userRepository.save(user);
+            transaction.commit();
+
+        }
+        Authentication auth = new UsernamePasswordAuthenticationToken(email,"kakao" );
+        return authenticationManager.authenticate(auth);
+    }
+}


### PR DESCRIPTION
로그인 인증 방식을 안드로이드 단에서 인증하고 정보를 주는 방식으로 되어있는데 
이 방식은 url 노출시 보안이 위험합니다.
(/user/login 으로 누구나 호출가능) 
즉 안드로이드에서 kakao 로 가는 access토큰을 받고 
저희 쪽에서도 인증을 한번더 해야 보안적으로 좋아집니다.
그리고 이 쪽 코드는 프론트랑 같이 테스트를 해야합니다.